### PR TITLE
Replaced checks to faction and humanlike with check to IsColonist

### DIFF
--- a/Source/Androids For RW1.1/Harmony/MapPawns_Patch.cs
+++ b/Source/Androids For RW1.1/Harmony/MapPawns_Patch.cs
@@ -63,7 +63,7 @@ namespace MOARANDROIDS
                     List<Pawn> allPawns = __instance.AllPawns;
                     for (int i = 0; i < allPawns.Count; i++)
                     {
-                        if (allPawns[i].Faction == Faction.OfPlayer && allPawns[i].HostFaction == null && allPawns[i].RaceProps.Humanlike && !allPawns[i].IsSurrogateAndroid(false, true))
+                        if (allPawns[i].HostFaction == null && allPawns[i].IsColonist && !allPawns[i].IsSurrogateAndroid(false, true))
                         {
                             list.Add(allPawns[i]);
                         }


### PR DESCRIPTION
Replaced checks to allPawns[i]’s Faction and RaceProps.Humanlike properties to a single check on IsColonist, without mods this does the same thing but helps prevent the HarmonyPatch from erroneously removing non android pawns when IsColonist is patched 