### PR TITLE
Fixes

### DIFF
--- a/1.1/Defs/RecipeDefs/Recipes_Surgery_Installations.xml
+++ b/1.1/Defs/RecipeDefs/Recipes_Surgery_Installations.xml
@@ -415,7 +415,7 @@
 	<!---->
 
   <RecipeDef ParentName="SurgeryAndroid">
-		<defName>InstallDrillArm</defName>
+		<defName>InstallMiningArm</defName>
 		<label>install mining arm</label>
 		<description>Installs a mining arm.</description>
 		<workerClass>MOARANDROIDS.Recipe_InstallArtificialBodyPartAndroid</workerClass>


### PR DESCRIPTION
Royal dlc introduce drill arm and surgery bill was in conflict with mod InstallDrillArm. Replacing this name allow to install royal dlc drill arm in vanilla colonist.

Vanilla Drill arm surgery is in:
RimWorld\Data\Royalty\Defs\HediffDefs\Hediffs_BodyParts_Prosthetic_Empire.xml